### PR TITLE
Print debug info for maps

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -11,7 +11,7 @@ from io import StringIO
 import asyncpg
 from discord.ext import commands
 
-from utils.misc import run_process
+from utils.misc import run_process_shell
 from utils.text import plural, render_table
 
 log = logging.getLogger(__name__)
@@ -116,7 +116,7 @@ class Admin(commands.Cog, command_attrs=dict(hidden=True)):
 
         content = []
         try:
-            stdout, stderr = await run_process(cmd)
+            stdout, stderr = await run_process_shell(cmd)
         except RuntimeError as exc:
             content.append(str(exc))
         else:

--- a/cogs/map_testing/__init__.py
+++ b/cogs/map_testing/__init__.py
@@ -182,6 +182,9 @@ class MapTesting(commands.Cog):
                     await self.upload_submission(subm)
                 else:
                     await subm.set_state(SubmissionState.VALIDATED)
+                debug_output = await subm.debug_map()
+                if debug_output:
+                    await message.channel.send("```" + debug_output + "```")
 
     @commands.Cog.listener('on_raw_message_edit')
     async def handle_submission_edit(self, payload: discord.RawMessageUpdateEvent):
@@ -248,6 +251,9 @@ class MapTesting(commands.Cog):
 
         else:
             subm = Submission(message)
+            debug_output = await subm.debug_map()
+            if debug_output:
+                await message.reply("```" + debug_output + "```", mention_author=False)
 
         await self.upload_submission(subm)
         log.info('%s approved submission %r in channel #%s', user, subm.filename, channel)

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -11,7 +11,7 @@ import psutil
 from discord.ext import commands
 
 from data.countryflags import FLAG_UNK
-from utils.misc import run_process
+from utils.misc import run_process_shell
 from utils.text import human_timedelta
 
 log = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ class Misc(commands.Cog):
     async def get_latest_commits(self, num: int=3) -> str:
         fmt = fr'[\`%h\`]({GH_URL}/commit/%H) %s (%ar)'
         cmd = f'git log master -{num} --no-merges --format="{fmt}"'
-        stdout, _ = await run_process(cmd)
+        stdout, _ = await run_process_shell(cmd)
         return stdout
 
     @commands.command()


### PR DESCRIPTION
This will print the debug info for maps that are uploaded to the testing servers in their respective testing channel.
The debug text is generated by the `debug_load` and `ddnet_checks` binaries from the [twmap](https://gitlab.com/Patiga/twmap) tool.

This means that it will print debug info, whenever

1. when a testing channel is first created for a map
2. when the mapper or tester uploads a map update
3. when a tester marks a map in the testing channel for upload

Note that at 3. the debug info is written in a reply, which requires discord.py with version >=1.6

**This requires the binaries `debug_load` and `ddnet_checks` to be present in the directory `data/map-testing`.**

I don't expect this to result in much spam, or at least not in bad spam. The most spam I expect comes from the `ddnet_checks` binary, which is currently only used to check for game tiles with invalid orientation. For each block with invalid rotation, this will print one line. Since invalid rotation of game tiles also results in broken physics, I think that this is fine.
Remember that discord also collapses long messages, so one bad map won't disturb much.

I renamed `run_process` to `run_process_shell`, because I also added `run_process_exec`, which follows the naming convention for these functions (https://docs.python.org/3/library/asyncio-subprocess.html#creating-subprocesses).