### PR TITLE
Fix webhook exception spam in logs

### DIFF
--- a/cogs/moderator.py
+++ b/cogs/moderator.py
@@ -194,7 +194,7 @@ class Moderator(commands.Cog):
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
         author = message.author
-        if message.guild is None or message.guild.id != GUILD_DDNET or message.channel.id == CHAN_REPORTS \
+        if message.guild is None or message.guild.id != GUILD_DDNET or message.author.bot or message.channel.id == CHAN_REPORTS \
            or is_staff(author) or f'<@&{ROLE_MODERATOR}>' not in message.content:
             return
 


### PR DESCRIPTION
Logs:
```
[2022-05-21 19:25:10][ERROR][bot]: Event 'on_message' caused an exception
Traceback (most recent call last):
  File "/home/teeworlds/pybot/ddnet-discordbot/.venv/lib/python3.9/site-packages/discord/client.py", line 343, in _run_event
    await coro(*args, **kwargs)
  File "/home/teeworlds/pybot/ddnet-discordbot/cogs/moderator.py", line 198, in on_message
    or is_staff(author) or f'<@&{ROLE_MODERATOR}>' not in message.content or message.author.bot:
  File "/home/teeworlds/pybot/ddnet-discordbot/cogs/moderator.py", line 29, in is_staff
    return any(r.id in (ROLE_ADMIN, ROLE_MODERATOR) for r in member.roles)
AttributeError: 'User' object has no attribute 'roles'
```
Happens everytime someone sends a message via webhook in #developer