### PR TITLE
Ignore github references found in inline code lines

### DIFF
--- a/cogs/github.py
+++ b/cogs/github.py
@@ -143,10 +143,13 @@ class Github(commands.Cog):
         if message.channel.id != CHAN_DEVELOPER or (message.content and message.content[0] == self.bot.command_prefix) or message.author.bot or self.ratelimited():
             return
         
-        codeblocks = re.findall(r"```(?:\w+\n)?(.+?)```", message.content, flags=re.DOTALL)
-        for codeblock in codeblocks:
-            message.content = message.content.replace(f"```{codeblock}```", '')
-        
+        codeblocks = re.findall(r"```(?:\w+\n)?([\s\S]+?)```|`(?:\w+)?(.+?)`", message.content, flags=re.DOTALL)
+        for triple_backtick, single_backtick in codeblocks:
+            if triple_backtick:
+                message.content = message.content.replace(f"{triple_backtick}", '')
+            elif single_backtick:
+                message.content = message.content.replace(f"{single_backtick}", '')
+
         matches = re.finditer(_ISSUE_RE, message.content)
         links = []
         for match in matches:
@@ -179,5 +182,5 @@ class Github(commands.Cog):
             self.ratelimit = error
 
 
-def setup(bot: commands.bot):
-    bot.add_cog(Github(bot))
+async def setup(bot: commands.bot):
+    await bot.add_cog(Github(bot))


### PR DESCRIPTION
The bot mistakenly links to issues/PRs mentioned in single backtick code lines. The fix should address this issue.