### PR TITLE
Set bot as initial_ready if map channel got reset from evaluated maps

### DIFF
--- a/cogs/map_testing/__init__.py
+++ b/cogs/map_testing/__init__.py
@@ -169,8 +169,10 @@ class MapTesting(commands.Cog):
             subm = Submission(message)
             if map_channel.filename == str(subm):
                 by_mapper = str(author.id) in map_channel.mapper_mentions
+                # set bot as initial ready so the map only needs one ready to be moved to evaluated maps again
+                initial_ready = self.bot.user.mention
                 if by_mapper and map_channel.state in (MapState.WAITING, MapState.READY):
-                    await map_channel.set_state(state=MapState.TESTING)
+                    await map_channel.set_state(state=MapState.RC, ready_state_set_by=initial_ready)
 
                 if by_mapper or is_staff(author) or author == self.bot.user:
                     await self.upload_submission(subm)

--- a/cogs/map_testing/map_channel.py
+++ b/cogs/map_testing/map_channel.py
@@ -117,7 +117,7 @@ class MapChannel:
 
         if category_id != self.category_id:
             options['category'] = category = self.guild.get_channel(category_id)
-            options['position'] = category.channels[-1].position + 1 if state is (MapState.TESTING or MapState.RC) else 0
+            options['position'] = category.channels[-1].position + 1 if state in [MapState.TESTING, MapState.RC] else 0
 
         options['topic'] = f"{self.topic}"
 

--- a/cogs/map_testing/map_channel.py
+++ b/cogs/map_testing/map_channel.py
@@ -117,7 +117,7 @@ class MapChannel:
 
         if category_id != self.category_id:
             options['category'] = category = self.guild.get_channel(category_id)
-            options['position'] = category.channels[-1].position + 1 if state is MapState.TESTING else 0
+            options['position'] = category.channels[-1].position + 1 if state is (MapState.TESTING or MapState.RC) else 0
 
         options['topic'] = f"{self.topic}"
 


### PR DESCRIPTION
As suggested by VeNa on Discord:
> @murpi is it possible to make map in ready section  in 1 ready if the map was ready before, or if a map is ready and mapper post another version, it doesn't move from ready section

Essentially, if a map channel state was set to ready, and the mapper uploads an updated map version in the map channel, the bot shifts the channel back to the regular testing category and changes the channel state back to testing. This means the channel needs 2 ready's again in order to be moved back to evaluated maps. This adjustment should change it so it only one ready is required by setting the bot as the initial_ready and the state to RC. Kinda hacky, but I can't really think of a better way atm.