### PR TITLE
MT: Use message.reactions instead of checking the raw payload data

### DIFF
--- a/cogs/map_testing/__init__.py
+++ b/cogs/map_testing/__init__.py
@@ -211,12 +211,11 @@ class MapTesting(commands.Cog):
         if not ('attachments' in data and data['attachments'] and data['attachments'][0]['filename'].endswith('.map')):
             return
 
-        # don't handle already processed submissions
-        if 'reactions' in data and data['reactions'][0]['emoji']['name'] == str(SubmissionState.PROCESSED):
-            return
-
         channel = self.bot.get_channel(payload.channel_id)
         message = self.bot.get_message(payload.message_id) or await channel.fetch_message(payload.message_id)
+
+        if any(str(SubmissionState.PROCESSED) == reaction.emoji for reaction in message.reactions):
+            return
 
         isubm = InitialSubmission(message)
         await self.validate_submission(isubm)


### PR DESCRIPTION
**The issue:**

For whatever reason, after the bot has been restarted, it seems like the bot receives a message update event in the submit-maps channel by the discord api. This event triggers the `handle_submission_edit` function. The very last and crucial check:
https://github.com/ddnet/ddnet-discordbot/blob/16c12f39dca7c37c9a45087c01edae9b557143fb/cogs/map_testing/__init__.py#L215
 doesn't work, because `'reactions'` does not exist in the `payload.data`, which then leads to the validation of previously processed submissions. As the channel already exists, the bot updates the submission state to ERROR (:x:) and returns a ValueError with content: A channel for this map already exists.

This PR should hopefully fix the Submission error states in the submit maps channel.

I'm still not quite sure as to why the bot receives a message update gateway event by the discord api randomly though. Pretty weird.